### PR TITLE
add gomake build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 
 bin/
 gopath/
+dist/

--- a/gomake
+++ b/gomake
@@ -1,0 +1,297 @@
+#!/bin/bash
+set -e
+
+ : ${target_name:=dist}
+ : ${work_path:=.}
+ : ${app:=$(basename $(cd "${work_path}"; pwd))}
+ : ${repo:=$(git config --get remote.origin.url | sed -n 's/.*@\(.*\)\.git/\1/p' | tr : /)}
+ : ${osarchi:="$(go env GOHOSTOS)-$(go env GOHOSTARCH)"}
+ : ${release_osarchi:="linux-amd64,darwin-amd64,windows-amd64"}
+ : ${version:=0}
+ : ${token:=}
+ : ${upx:=}
+
+read -d '' helper <<EOF || true
+Usage: gomake [-v version][-t token] command...
+  gomake is a script to build go apps
+
+  command
+      clean                 clean '${target_name}/' directory
+      build                 build (current platform only by default)
+      quality               Format, Fix, check error handled, lint, vet, misspell, ineffassign, Gocyclo
+      test                  run go tests
+      release               clean, build all platform, test, check git is clean, tag, push tag & build ZIPs
+      gomake_update         self updating by downloading and replacing with latest version
+
+         default is 'clean build test quality'
+
+  -v, --version=version     version of the app
+  -h, --help                this helper
+  -t, --token=token         token to push releases
+  -W, --work-path=path      set working path, default is ./
+EOF
+
+go_files=`find . -name '*.go' 2> /dev/null | grep -v ${target_name}/ | grep -v vendor/ | grep -v .git`
+err_count=0
+
+#color_red() {
+#    echo -n -e "\e[0;31m"
+#}
+#
+#color_reset() {
+#    echo -n -e "\e[0m"
+#}
+
+echo_red() {
+    echo -n -e "\e[0;31m"
+    echo "${@}"
+    echo -n -e "\e[0m"
+}
+
+echo_purple() {
+    echo -e "\e[0;35m${@}\e[0m"
+}
+
+echo_green() {
+    echo -e "\e[0;32m${@}\e[0m"
+}
+
+echo_yellow() {
+    echo -e "\e[0;93m${@}\e[0m"
+}
+
+err_count() {
+    c=$(echo -e "${1}" | wc -l)
+    ((err_count+=${c}))
+}
+
+gomake_update() {
+    echo_green "Downloading gomake"
+    wget -q -O ${work_path}/gomake.tmp https://raw.githubusercontent.com/n0rad/gomake/master/gomake
+    chmod +x ${work_path}/gomake.tmp
+    mv ${work_path}/gomake.tmp ${work_path}/$0
+}
+
+clean() {
+    echo_green "Cleaning"
+    rm -Rf ${work_path}/${target_name}
+}
+
+build() {
+    start=`date +%s`
+
+    [ -z "$1" ] || osarchi="$1"
+    [ ! -z ${version+x} ] || version="0"
+
+    mkdir -p ${work_path}/${target_name}/bindata
+
+    if [ `type -t pre-build`"" == 'function' ]; then
+        pre-build
+    fi
+
+    [ -f /usr/bin/upx ] || (echo "upx is required to build" && exit 1)
+
+    echo_green "Goimports"
+    [ -f ${GOPATH}/bin/goimports ] || go get -u golang.org/x/tools/cmd/goimports
+    goimports -w ${go_files}
+
+#    echo_green "Save Dependencies"
+#    [ -f ${GOPATH}/bin/godep ] || go get github.com/tools/godep
+#    godep save ./${work_path}/... || echo_yellow "Cannot save dependencies. Continuing"
+
+    if [ "$(ls -A ${work_path}/${target_name}/bindata)" ]; then
+        [ -f ${GOPATH}/bin/go-bindata ] || go get -u github.com/jteeuwen/go-bindata/...
+        go-bindata -nomemcopy -pkg dist -prefix dist/bindata -o ${work_path}/${target_name}/bindata.go ${work_path}/${target_name}/bindata/...
+    fi
+
+    IFS=',' read -ra current <<< "$osarchi"
+    for e in "${current[@]}"; do
+        echo_green "Building $e"
+
+        $(cd ${work_path} && GOOS="${e%-*}" GOARCH="${e#*-}" godep go build -ldflags "-s -w -X main.BuildTime=`date -u '+%Y-%m-%d_%H:%M:%S_UTC'` -X main.Version=${version}-`git rev-parse --short HEAD`" \
+            -o ${target_name}/${app}-v${version}-${e}/${app})
+
+        if [ ${upx} ]; then
+            echo_green "Compressing ${e}"
+            upx ${work_path}/${target_name}/${app}-v${version}-${e}/${app} &> /dev/null
+        fi
+
+        if [ "${e%-*}" == "windows" ]; then
+            mv ${work_path}/${target_name}/${app}-v${version}-${e}/${app} ${work_path}/${target_name}/${app}-v${version}-${e}/${app}.exe
+        fi
+    done
+    echo_purple "Build duration : $((`date +%s`-${start}))s"
+}
+
+
+install() {
+    echo_green "Installing"
+    cp ${work_path}/${target_name}/${app}-v${version}-$(go env GOHOSTOS)-$(go env GOHOSTARCH)/${app}* ${GOPATH}/bin/
+}
+
+quality() {
+    start=`date +%s`
+    cd ${work_path}
+
+    echo_green "Format"
+    gofmt -w -s ${go_files}
+
+    echo_green "Fix"
+    go tool fix ${go_files}
+
+    echo_green "Err check"
+    [ -f ${GOPATH}/bin/errcheck ] || go get -u github.com/kisielk/errcheck
+    res=$(errcheck ./... | grep -v 'vendor/' | grep -v 'Close(' | grep -v '_test.go')
+    err_count "${res}"
+    echo_red "${res}"
+
+    echo_green "Lint"
+    [ -f ${GOPATH}/bin/golint ] || go get -u github.com/golang/lint/golint
+    for i in ${go_files}; do
+        golint ${i} | grep -v 'should have comment ' || true
+    done
+
+    echo_green "Vet"
+    go tool vet ${go_files} || true
+
+    echo_green "Misspell"
+    [ -f ${GOPATH}/bin/misspell ] || go get -u github.com/client9/misspell/cmd/misspell
+    misspell -source=text ${go_files}
+
+    echo_green "Ineffassign"
+    [ -f ${GOPATH}/bin/ineffassign ] || go get -u github.com/gordonklaus/ineffassign
+    for i in ${go_files}; do
+        ineffassign -n ${i} || true
+    done
+
+    echo_green "Gocyclo"
+    [ -f ${GOPATH}/bin/gocyclo ] || go get -u github.com/fzipp/gocyclo
+    gocyclo -over 15 ${go_files} || true
+
+    cd -
+    echo_purple "Quality duration : $((`date +%s`-${start}))s"
+}
+
+require_clean_work_tree() {
+    # Update the index
+    git update-index -q --ignore-submodules --refresh
+    err=0
+
+    # Disallow unstaged changes in the working tree
+    if ! git diff-files --quiet --ignore-submodules --
+    then
+        echo_red "cannot release: you have unstaged changes."
+        git diff-files --name-status -r --ignore-submodules -- >&2
+        err=1
+    fi
+
+    # Disallow uncommitted changes in the index
+    if ! git diff-index --cached --quiet HEAD --ignore-submodules --
+    then
+        echo_red "cannot release: your index contains uncommitted changes."
+        git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2
+        err=1
+    fi
+
+    if [ ${err} = 1 ]
+    then
+        echo_red "Please commit or stash them."
+        exit 1
+    fi
+}
+
+release() {
+    start=`date +%s`
+    if [ "${repo%%/*}" != "github.com" ]; then
+        echo "Push to '${repo%%/*}' not implemented"
+        exit 1
+    fi
+    if [ -z "${version}" ] || [ "${version}" == "0" ]; then
+        echo_red "please set version to release"
+        exit 1
+    fi
+    if [ -z "${token}" ]; then
+        echo_red "please set token to release"
+        exit 1
+    fi
+
+    github_repo=${repo#*/}
+
+    clean
+    build ${release_osarchi}
+    test
+    quality
+    require_clean_work_tree
+
+    echo_green "Compress release"
+    cd ${work_path}/${target_name}
+    for i in *-* ; do
+        if [ -d "$i" ]; then
+            tar czf ${i}.tar.gz ${i}
+        fi
+    done
+    cd -
+
+    git tag v${version} -a -m "Version $version"
+    git push --tags
+
+    sleep 5
+
+    posturl=$(curl --data "{\"tag_name\": \"v${version}\",\"target_commitish\": \"master\",\"name\": \"v${version}\",\"body\": \"Release of version ${version}\",\"draft\": false,\"prerelease\": false}" https://api.github.com/repos/${github_repo}/releases?access_token=${token} | grep "\"upload_url\"" | sed -ne 's/.*\(http[^"]*\).*/\1/p')
+
+    for i in ${work_path}/${target_name}/*.tar.gz ; do
+        fullpath=$(ls ${i})
+        filename=${fullpath##*/}
+        curl -i -X POST -H "Content-Type: application/x-gzip" --data-binary "@${fullpath}" "${posturl%\{?name,label\}}?name=${filename}&label=${filename}&access_token=${token}"
+    done
+    echo_purple "Release duration : $((`date +%s`-${start}))s"
+}
+
+test() {
+    start=`date +%s`
+    echo_green "Testing"
+    godep go test -cover $(go list ${work_path}/... | grep -v vendor/)
+
+    echo_purple "Test duration : $((`date +%s`-${start}))s"
+}
+
+#########################################
+#########################################
+
+global_start=`date +%s`
+
+commands=()
+while [ $# -gt 0 ]; do
+    case "${1}" in
+        -h|--help)  echo "${helper}"; exit 0;;
+        --version=*)version="${1#*=}"; shift;;
+        --token=*)  token="${1#*=}"; shift;;
+        --work-path=*) work_path="${1#*=}"; shift;;
+        -v)         version="${2}"; [ $# -gt 1 ] || (echo_red "Missing argument for ${1}"; exit 1); shift 2;;
+        -t)         token="${2}"; [ $# -gt 1 ] || (echo_red "Missing argument for ${1}"; exit 1); shift 2;;
+        -W)         work_path="${2}"; [ $# -gt 1 ] || (echo_red "Missing argument for ${1}"; exit 1); shift 2;;
+        --)         shift; commands+=("${@}"); break;;
+        *)          commands+=("${1}"); shift;;
+    esac
+done
+
+if [ -f ${work_path}/gomake.cfg ]; then
+ . ${work_path}/gomake.cfg
+fi
+
+if [ ${#commands[@]} -eq 0 ]; then
+    commands=(clean build test quality)
+fi
+command_count=0
+for i in "${commands[@]}"; do
+    case ${i} in
+        test|build|release|clean|quality|gomake_update) ${i}; ((++command_count));;
+        *)                                              echo_red "Unknown command '${i}'"; echo ${helper}; exit 1;;
+    esac
+done
+
+if [ ${command_count} -gt 1 ]; then
+    echo_purple "Global duration : $((`date +%s`-global_start))s"
+fi
+
+exit 0


### PR DESCRIPTION
I propose to add gomake as the build script. We are using it @blablacar to build all our projects.

It's a simple shell script that handle all basic stuff needed.

Here is a example of a complete build : 
```bash
$ ./gomake
Cleaning
Goimports
Building linux-amd64
Build duration : 0s
Testing
?       github.com/blablacar/acserver   [no test files]
Test duration : 1s
Format
Fix
Err check
main.go:135:14  os.RemoveAll(path.Join(directory, "tmp"))
main.go:374:11  w.Write([]byte("item already uploaded"))
main.go:451:16  reportFailure(num, w, "client reported failure", msg.Reason)
main.go:456:16  reportFailure(num, w, "manifest wasn't uploaded", msg.Reason)
main.go:461:16  reportFailure(num, w, "signature wasn't uploaded", msg.Reason)
main.go:466:16  reportFailure(num, w, "ACI wasn't uploaded", msg.Reason)
main.go:474:16  reportFailure(num, w, "Internal Server Error", msg.Reason)
Lint
Vet
Misspell
Ineffassign
Gocyclo
/home/n0rad/Work/go/src/github.com/blablacar/acserver
Quality duration : 1s
Global duration : 2s
```

It also handle releases by
- building for a platform list
- checking git is clean
- checking there is no test failure
- tag
- push to github releases
- ...
see : https://github.com/blablacar/acserver/releases

It's not perfect yet, but it's doing the job
